### PR TITLE
Updates to 'concurrent' tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         runner_image: ["openjdk-11-lein-2.9.6", "temurin-21-lein-bullseye-slim", "temurin-24-lein-bullseye-slim"]
 
     container:
-      image: clojure:{{ matrix.runner_image }}
+      image: clojure:${{ matrix.runner_image }}
 
     steps:
     - uses: actions/checkout@v4.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runner_image: ["openjdk-11-lein-2.9.6", "temurin-21-lein-bullseye-slim", "temurin-24-lein-bullseye-slim"]
+
     container:
-      image: clojure:openjdk-11-lein-2.9.6
+      image: clojure:{{ matrix.runner_image }}
 
     steps:
     - uses: actions/checkout@v4.2.1

--- a/test/utility_belt/concurrent_test.clj
+++ b/test/utility_belt/concurrent_test.clj
@@ -1,6 +1,8 @@
 (ns utility-belt.concurrent-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [clojure.tools.logging :as log]
+   [utility-belt.compile :as compile]
    [utility-belt.concurrent :as concurrent]))
 
 (deftest parallel-tasks-test
@@ -19,3 +21,31 @@
         (is (= 6 (count results)))
         (is (= #{"test-0" "test-1" "test-2"}
                (into #{} results)))))))
+
+(compile/compile-if concurrent/virtual-threads-available?
+                    (defn get-executor []
+                      (log/info "using virtual threads")
+                      (java.util.concurrent.Executors/newVirtualThreadPerTaskExecutor))
+
+                    (defn get-executor []
+                      (log/info "using fixed thread pool")
+                      (java.util.concurrent.Executors/newFixedThreadPool 3)))
+
+(deftest custom-executor-test
+  (let [counter (atom 0)
+        task (fn task' []
+               (swap! counter inc))
+        exec (get-executor)
+        results (concurrent/run-tasks exec
+                                      {:tasks [task
+                                               task
+                                               task
+                                               task
+                                               task
+                                               task]
+                                       :max-wait-time-ms 500})]
+
+    (concurrent/shutdown-task-pool exec)
+
+    (is (= [1 2 3 4 5 6]
+           (sort results)))))


### PR DESCRIPTION
update ub.concurrent to support any type of thread pool executor, including virtual threads