### PR TITLE
Bugfix: clean up lifecycle hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,29 @@
-nuke-java-version:
+_nuke-java-version:
 	@rm -f .java-version
 
-run-tests-java-11: nuke-java-version
+_nuke-tmp-test-file:
+	@rm /tmp/ut-test-file
+
+run-tests-java-11: _nuke-java-version _nuke-tmp-test-file
 	@echo temurin-11 > .java-version
 	@echo "JAVA 11"
 	@lein test
+	@stat /tmp/ut-test-file
 
-run-tests-java-21: nuke-java-version
+
+run-tests-java-21: _nuke-java-version _nuke-tmp-test-file
 	@echo temurin-21 > .java-version
 	@echo "JAVA 21"
 	@lein test
+	@stat /tmp/ut-test-file
 
 
 run-tests: run-tests-java-11 run-tests-java-21
 
-
 publish:
 	@lein deploy clojars
+
+
+help:
+	@echo "Available tasks:"
+	@grep -E '^[a-z-]+:' ./Makefile | sed 's/:.*//g'

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.lukaszkorecki/utility-belt "2.2.1"
+(defproject org.clojars.lukaszkorecki/utility-belt "2.2.2-SNAPSHOT"
   :description "Some of the tools you'll ever need to fight crime and write Clojure stuffs"
   :license "MIT"
   :url "https://github.com/lukaszkorecki/utility-belt"
@@ -9,7 +9,7 @@
   :dependencies [[org.clojure/clojure "1.12.0"]
                  [com.stuartsierra/component "1.1.0"]
                  [org.clojure/tools.logging "1.3.0"]
-                 [cheshire "5.13.0"]]
+                 [cheshire "6.0.0"]]
 
   :global-vars {*warn-on-reflection* true}
   :profiles {:dev

--- a/src/utility_belt/component/system.clj
+++ b/src/utility_belt/component/system.clj
@@ -39,8 +39,9 @@
   (def app (atom nil))
 
   (defn -main [& _args]
-    (component/init-app-system {:store app
-                                :component-map-fn  system/production)))
+    (component/setup-for-production {:store app
+                                     :service \"my service\"
+                                     :component-map-fn  system/production)))
   ```
   "
   [{:keys [store service component-map-fn]}]

--- a/src/utility_belt/lifecycle.clj
+++ b/src/utility_belt/lifecycle.clj
@@ -17,8 +17,11 @@
   (log/debugf "registered hook '%s'" name)
   (let [hook* (Thread. ^Runnable
                        (fn hook' []
-                         (log/debugf "running shutdown hook '%s'" name)
-                         (hook-fn)))]
+                         (try
+                           (log/debugf "executing shutdown hook '%s'" name)
+                           (hook-fn)
+                           (catch Throwable err
+                             (log/errorf err "failed to execute shutdown hook '%s'" name)))))]
     (Runtime/.addShutdownHook runtime hook*)
     (swap! registerd-hooks assoc name hook*)))
 

--- a/src/utility_belt/lifecycle.clj
+++ b/src/utility_belt/lifecycle.clj
@@ -5,29 +5,29 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^{:private true :doc "Shutdown hook store"}
-  hooks
-  (atom [[::shutdown-agents shutdown-agents]]))
+(defonce runtime (Runtime/getRuntime))
+
+(defonce registerd-hooks (atom {}))
 
 (defn add-shutdown-hook
-  "Register a function to run when the application *gracefully* shuts down.
-  Useful for stopping the Component system or other resources that have a life cycle."
+  "Register a shutdown hook with the JVM. The hook identified by a keyword will  be executed when the JVM shuts down."
   [name hook-fn]
-  (log/infof "registered hook '%s'" name)
-  (swap! hooks conj [name hook-fn]))
+  {:pre [(keyword? name)
+         (fn? hook-fn)]}
+  (log/debugf "registered hook '%s'" name)
+  (let [hook* (Thread. ^Runnable
+                       (fn hook' []
+                         (log/debugf "running shutdown hook '%s'" name)
+                         (hook-fn)))]
+    (Runtime/.addShutdownHook runtime hook*)
+    (swap! registerd-hooks assoc name hook*)))
 
-(defn run-registered-hooks
-  []
-  (mapv (fn [[name hook-fn]]
-          (try
-            (log/infof "running shutdown hook '%s'" name)
-            (hook-fn)
-            (catch Exception err
-              (log/errorf err "shutdown hook '%s' failed, %s" name err))))
-        @hooks))
+(add-shutdown-hook ::shutdown-agents shutdown-agents)
 
 (defn register-shutdown-hooks!
-  "Install the shutdown handler, which will run any registered shutdown hooks."
+  "Install the shutdown handler, which will run any registered shutdown hooks.
+  If you don't care about the order of execution, pass a map with hooks.
+  Otherwise, pass a vector of tuples with the name and the function to run - hooks are going to run in reverse order"
   [hooks]
   {:pre [(seq hooks)
          (every? (fn [[name hook-fn]]
@@ -36,6 +36,16 @@
                  hooks)]}
   (mapv (fn [[name hook-fn]]
           (add-shutdown-hook name hook-fn))
-        hooks)
-  (Runtime/.addShutdownHook (Runtime/getRuntime)
-                            (Thread. ^Runnable run-registered-hooks)))
+        hooks))
+
+(defn remove-shutdown-hooks!
+  "Clear all registered shutdown hooks"
+  []
+  (doseq [[name hook*] @registerd-hooks]
+    (log/debugf "removing shutdown hook '%s'" name)
+    (try
+      (Runtime/.removeShutdownHook runtime hook*)
+      (catch Exception e
+        (log/errorf e "failed to remove shutdown hook '%s'" name))))
+
+  (reset! registerd-hooks {}))


### PR DESCRIPTION
This does two things:

- cleans up and simplifies `lifecycle` namespace implementation - this code has been unchanged since ~2017 and was based on wrong assumptions 
- the clean up fixes an issue when using `system/setup-for-production` - now the system will shutdown cleanly when JVM stops 🤦 

Released as `2.2.2-SNAPSHOT`