### PR TITLE
Introduce namespace for signal handling with exit code 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### v2.5.0 - **unreleased**
+
+* feat: sets up better unix signal handler, so that when JVM exit is triggered by SIGTERM or SIGKILL and system exits cleanly, exit code 0 is used. 
+
+### v2.4.0
+
+* feat: simplify development & test system management code by using `c.t.namespace` better
+
 ### v2.3.0 (2025-07-11)
 
 *   feat: Add simple Jetty component and tests

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.lukaszkorecki/utility-belt "2.4.0"
+(defproject org.clojars.lukaszkorecki/utility-belt "2.5.0-SNAPSHOT"
   :description "Some of the tools you'll ever need to fight crime and write Clojure stuffs"
   :license "MIT"
   :url "https://github.com/lukaszkorecki/utility-belt"

--- a/src/utility_belt/component/system.clj
+++ b/src/utility_belt/component/system.clj
@@ -7,6 +7,7 @@
    [utility-belt.compile :as compile]
    [utility-belt.component :as util.component]
    [utility-belt.lifecycle :as lifecycle]
+   [utility-belt.signal-handlers :as signal]
    [utility-belt.type :as type]))
 
 (defn fn-sym->ns-sym
@@ -46,7 +47,8 @@
                                      :component-map-fn  system/production)))
   ```
   "
-  [{:keys [store service component-map-fn]}]
+  [{:keys [store service component-map-fn use-exit-code-zero-for-graceful-shutdown?]
+    :or {use-exit-code-zero-for-graceful-shutdown? true}}]
   {:pre [(type/atom? store)
          (or (fn? component-map-fn)
              (qualified-symbol? component-map-fn))]}
@@ -60,7 +62,9 @@
     (lifecycle/add-shutdown-hook :shutdown-system (fn stop! []
                                                     (log/infof "stopping %s" svc-name)
                                                     (swap! store
-                                                           #(when % (component/stop-system %))))))
+                                                           #(when % (component/stop-system %)))))
+    (when use-exit-code-zero-for-graceful-shutdown?
+      (signal/use-exit-code-zero-for-graceful-exit!)))
 
   store)
 

--- a/src/utility_belt/signal_handlers.clj
+++ b/src/utility_belt/signal_handlers.clj
@@ -1,0 +1,23 @@
+(ns utility-belt.signal-handlers
+  (:import [sun.misc Signal SignalHandler]))
+
+(deftype ExitZeroHandler []
+  SignalHandler
+  (handle [_this _signal] (System/exit 0)))
+
+(def exit-zero-handler (ExitZeroHandler.))
+
+(defn exit-zero-on-signal
+  [^String signal]
+  (Signal/handle (Signal. signal) exit-zero-handler))
+
+#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
+(defn use-exit-code-zero-for-graceful-exit!
+  "By default, the JVM handles INT and TERM signals by return status
+  codes by triggering graceful shutdown and returning a status code
+  based on the signal that initiated it (128 + unix value of the
+  signal). This is great, except that the exit code should be 0 if, in
+  fact things did exit gracefully."
+  []
+  (exit-zero-on-signal "TERM")
+  (exit-zero-on-signal "INT"))

--- a/src/utility_belt/signal_handlers.clj
+++ b/src/utility_belt/signal_handlers.clj
@@ -11,7 +11,6 @@
   [^String signal]
   (Signal/handle (Signal. signal) exit-zero-handler))
 
-#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
 (defn use-exit-code-zero-for-graceful-exit!
   "By default, the JVM handles INT and TERM signals by return status
   codes by triggering graceful shutdown and returning a status code


### PR DESCRIPTION
See the description. I'm tempted to add this to the `setup-for-production`, but leaving this as an opt-in thing instead makes utility-belt continue to work on "silly" platforms (Windows)

Edit: I've added it as a default-on to `setup-for-production`