### PR TITLE
Feature: virtual thread support in concurrent utils

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        runner_image: ["openjdk-11-lein-2.9.6", "temurin-21-lein-bullseye-slim", "temurin-24-lein-bullseye-slim"]
+        runner_image: ["temurin-21-lein-bullseye-slim", "temurin-24-lein-bullseye-slim", "temurin-25-lein-bullseye-slim"]
 
     container:
       image: clojure:${{ matrix.runner_image }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### v3.0.0-SNAPSHOT
+
+**Breaking change**
+
+JVM 21 or higher is required.
+
+* feat: add direct support for virtual threads (opt-in) to `run-task-in-parallel` and friend
+* chore: dependency update
+
 ### v2.5.0
 
 * feat: sets up better unix signal handler, so that when JVM exit is triggered by SIGTERM or SIGKILL and system exits cleanly, exit code 0 is used.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+java = "temurin-21"
+leiningen = "latest"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.lukaszkorecki/utility-belt "2.5.0"
+(defproject org.clojars.lukaszkorecki/utility-belt "3.0.0-SNAPSHOT"
   :description "Some of the tools you'll ever need to fight crime and write Clojure stuffs"
   :license "MIT"
   :url "https://github.com/lukaszkorecki/utility-belt"
@@ -8,10 +8,10 @@
 
   :dependencies [[org.clojure/clojure "1.12.4"]
                  [com.stuartsierra/component "1.2.0"]
-                 [org.clojure/tools.logging "1.3.0"]
+                 [org.clojure/tools.logging "1.3.1"]
                  [cheshire "6.1.0"]]
 
   :global-vars {*warn-on-reflection* true}
   :profiles {:dev
-             {:dependencies [[ch.qos.logback/logback-classic "1.5.22"]
+             {:dependencies [[ch.qos.logback/logback-classic "1.5.26"]
                              [ring/ring-jetty-adapter "1.15.3"]]}})

--- a/src/utility_belt/base64.clj
+++ b/src/utility_belt/base64.clj
@@ -16,8 +16,8 @@
   (byte-array
     ;; needs to cond on type to stop reflection
    (cond
-    (bytes? base64) (.decode decoder ^bytes base64)
-    (string? base64) (.decode decoder ^String base64))))
+     (bytes? base64) (.decode decoder ^bytes base64)
+     (string? base64) (.decode decoder ^String base64))))
 
 (defn decode->str
   "Decode from bytes or string to string"
@@ -33,8 +33,8 @@
   {:pre [(or (bytes? data) (string? data))
          (Charset/isSupported encoding)]}
   (cond
-   (bytes? data) data
-   (string? data) (.getBytes ^String data encoding)))
+    (bytes? data) data
+    (string? data) (.getBytes ^String data encoding)))
 
 (defn encode
   "Encode string or bytes to bytes"

--- a/test/utility_belt/concurrent_test.clj
+++ b/test/utility_belt/concurrent_test.clj
@@ -1,12 +1,11 @@
 (ns utility-belt.concurrent-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
-   [clojure.tools.logging :as log]
-   [utility-belt.compile :as compile]
    [utility-belt.concurrent :as concurrent]))
 
 (deftest parallel-tasks-test
-  (testing "tasks run in parallel"
+  (testing "tasks run in parallel with fixed thread pool"
     (let [task (fn task' []
                  (Thread/.getName (Thread/currentThread)))
           results (concurrent/run-tasks-in-parallel {:task-group-name "test"
@@ -20,95 +19,117 @@
       (testing "We run N tasks across M threads"
         (is (= 6 (count results)))
         (is (= #{"test-0" "test-1" "test-2"}
-               (into #{} results)))))))
+               (into #{} results))))))
 
-(compile/compile-if concurrent/virtual-threads-available?
-  (defn get-executor []
-    (log/info "using virtual threads")
-    (java.util.concurrent.Executors/newVirtualThreadPerTaskExecutor))
-
-  (defn get-executor []
-    (log/info "using fixed thread pool")
-    (java.util.concurrent.Executors/newFixedThreadPool 3)))
+  (testing "tasks run in parallel with virtual threads"
+    (let [task (fn task' []
+                 (let [thread (Thread/currentThread)]
+                   {:name (Thread/.getName thread)
+                    :virtual? (Thread/.isVirtual thread)}))
+          results (concurrent/run-tasks-in-parallel {:task-group-name "vtest"
+                                                     :virtual-threads? true
+                                                     :tasks [task
+                                                             task
+                                                             task
+                                                             task
+                                                             task
+                                                             task]})]
+      (testing "We run N tasks on virtual threads"
+        (is (= 6 (count results)))
+        (is (every? :virtual? results))
+        (is (every? #(str/starts-with? (:name %) "vtest-") results))))))
 
 (deftest custom-executor-test
-  (let [counter (atom 0)
-        task (fn task' []
-               (swap! counter inc))
-        exec (get-executor)
-        results (concurrent/run-tasks exec
-                                      {:tasks [task
-                                               task
-                                               task
-                                               task
-                                               task
-                                               task]
-                                       :max-wait-time-ms 500})]
+  (testing "custom executor with fixed thread pool"
+    (let [counter (atom 0)
+          task (fn task' []
+                 (swap! counter inc))
+          exec (concurrent/make-task-pool {:thread-count 3
+                                           :pool-name "custom-fixed"})
+          results (concurrent/run-tasks exec
+                                        {:tasks [task
+                                                 task
+                                                 task
+                                                 task
+                                                 task
+                                                 task]
+                                         :max-wait-time-ms 500})]
+      (concurrent/shutdown-task-pool exec)
+      (is (= [1 2 3 4 5 6]
+             (sort results)))))
 
-    (concurrent/shutdown-task-pool exec)
-
-    (is (= [1 2 3 4 5 6]
-           (sort results)))))
+  (testing "custom executor with virtual threads"
+    (let [counter (atom 0)
+          task (fn task' []
+                 (swap! counter inc))
+          exec (concurrent/make-task-pool {:pool-name "custom-virtual"
+                                           :virtual-threads? true})
+          results (concurrent/run-tasks exec
+                                        {:tasks [task
+                                                 task
+                                                 task
+                                                 task
+                                                 task
+                                                 task]
+                                         :max-wait-time-ms 500})]
+      (concurrent/shutdown-task-pool exec)
+      (is (= [1 2 3 4 5 6]
+             (sort results))))))
 
 (deftest scheduler-task-modes-test
   (testing "fixed rate"
-    ;; XXX: we could use with-open but JDK11's version of ScheduledThreadPoolExecutor doesn't implement Closeable
-    (let [pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})
-          start-time (System/currentTimeMillis)
-          state (atom [])
-          task (fn []
-                 (Thread/sleep 200)
-                 (swap! state conj (- (System/currentTimeMillis) ^long start-time)))
+    (with-open [^java.util.concurrent.ScheduledThreadPoolExecutor pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})]
+      (let [start-time (System/currentTimeMillis)
+            state (atom [])
+            task (fn []
+                   (Thread/sleep 200)
+                   (swap! state conj (- (System/currentTimeMillis) ^long start-time)))
 
-          round-down (fn [ms]
-                       (let [round-to 100]
-                         (* (quot ms round-to) round-to)))]
+            round-down (fn [ms]
+                         (let [round-to 100]
+                           (* (quot ms round-to) round-to)))]
 
-      (testing "scheduling a task with fixed-rate will cause the the task fire regardless of previous execution"
-        (concurrent/schedule-task pool {:handler task
-                                        ;; :mode ::concurrent/fixed-rate - DEFAULT
-                                        :period-ms 100})
+        (testing "scheduling a task with fixed-rate will cause the the task fire regardless of previous execution"
+          (concurrent/schedule-task pool {:handler task
+                                          ;; :mode ::concurrent/fixed-rate - DEFAULT
+                                          :period-ms 100})
 
-        (is (empty? @state))
+          (is (empty? @state))
 
-        (Thread/sleep 300)
+          (Thread/sleep 300)
 
-        (is (= [200] (mapv round-down @state)))
+          (is (= [200] (mapv round-down @state)))
 
-        (Thread/sleep 350)
+          (Thread/sleep 350)
 
-        (testing "after another 300ms, the task ran again, and the state is updated without waiting on previous tasks"
-          (is (= [200 400 600] (mapv round-down @state)))))
-
-      (concurrent/shutdown-scheduler-pool pool)))
+          (testing "after another 300ms, the task ran again, and the state is updated without waiting on previous tasks"
+            (is (= [200 400 600] (mapv round-down @state))))))))
 
   (testing "fixed delay"
-    (let [pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})
-          start-time (System/currentTimeMillis)
-          state (atom [])
-          task (fn []
-                 (Thread/sleep 200)
-                 (swap! state conj (- (System/currentTimeMillis) ^long start-time)))
+    (with-open [^java.util.concurrent.ScheduledThreadPoolExecutor pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})]
+      (let [start-time (System/currentTimeMillis)
+            state (atom [])
+            task (fn []
+                   (Thread/sleep 200)
+                   (swap! state conj (- (System/currentTimeMillis) ^long start-time)))
 
-          round-down (fn [ms]
-                       (let [round-to 100]
-                         (* (quot ms round-to) round-to)))]
+            round-down (fn [ms]
+                         (let [round-to 100]
+                           (* (quot ms round-to) round-to)))]
 
-      (testing "scheduling a task with fixed-delay will cause the the task fire only after previous finished"
-        (concurrent/schedule-task pool {:handler task
-                                        :mode ::concurrent/fixed-delay
-                                        :period-ms 100})
+        (testing "scheduling a task with fixed-delay will cause the the task fire only after previous finished"
+          (concurrent/schedule-task pool {:handler task
+                                          :mode ::concurrent/fixed-delay
+                                          :period-ms 100})
 
-        (is (empty? @state))
+          (is (empty? @state))
 
-        (Thread/sleep 300)
+          (Thread/sleep 300)
 
-        (testing "even though we scheduled it to run every 100ms, it only ran once because task blocks for 200ms"
-          (is (= [200] (mapv round-down @state))))
+          (testing "even though we scheduled it to run every 100ms, it only ran once because task blocks for 200ms"
+            (is (= [200] (mapv round-down @state))))
 
-        (Thread/sleep 300)
+          (Thread/sleep 300)
 
-        (testing "after another 300ms, the task ran again, and the state is updated"
-          (is (= [200 500] (mapv round-down @state))))
-
-        (concurrent/shutdown-scheduler-pool pool)))))
+          (testing "after another 300ms, the task ran again, and the state is updated"
+            (is (= [200 500] (mapv round-down @state)))))))))


### PR DESCRIPTION
> [!WARNING]
> This change drops support for JVMs older than 21
> Technically, it should work in JVM 18


- [x] adds `virtual-threads?` flag to `ut.concurrent` support, allowing to use vthreads for parallel task execution
- [x] deps update

Released as `3.0.0-SNAPSHOT`

https://clojars.org/org.clojars.lukaszkorecki/utility-belt/versions/3.0.0-SNAPSHOT