### PR TITLE
Feature: use stable scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v4.0.0 (unreleased)
+
+**Breaking change**
+
+* feat: migrates task scheduler code and Component to use `CronScheduler` as it's not succeptible to clock drift. See this PR for more details https://github.com/lukaszkorecki/utility-belt/pull/13
+
 ### v3.1.0
 
 * feat: add virtual thread support to Jetty component

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
   :dependencies [[org.clojure/clojure "1.12.4"]
                  [com.stuartsierra/component "1.2.0"]
                  [org.clojure/tools.logging "1.3.1"]
+                 [io.timeandspace/cron-scheduler "0.1"]
                  [cheshire "6.1.0"]]
 
   :global-vars {*warn-on-reflection* true}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.lukaszkorecki/utility-belt "3.1.0"
+(defproject org.clojars.lukaszkorecki/utility-belt "4.0.0-SNAPSHOT"
   :description "Some of the tools you'll ever need to fight crime and write Clojure stuffs"
   :license "MIT"
   :url "https://github.com/lukaszkorecki/utility-belt"

--- a/src/utility_belt/component/scheduler.clj
+++ b/src/utility_belt/component/scheduler.clj
@@ -28,9 +28,8 @@
 
 (defn create-task
   "Creates a scheduled task component, NOTE: it requires a :scheduler dependency to be present"
-  [{:keys [name period-ms delay-ms handler mode]
-    :or {delay-ms 0
-         mode ::concurrent/fixed-rate}
+  [{:keys [name period-ms delay-ms handler]
+    :or {delay-ms 0}
     :as opts}]
   {:pre [(not-empty name)
          (nat-int? period-ms)
@@ -50,7 +49,6 @@
                                                                            (handler (dissoc this :scheduler :task))
                                                                            (catch Throwable err
                                                                              (log/errorf err "recurring task '%s' failed" name))))
-                                                              :mode mode
                                                               :period-ms period-ms
                                                               :delay-ms delay-ms})))))
 

--- a/src/utility_belt/concurrent.clj
+++ b/src/utility_belt/concurrent.clj
@@ -1,15 +1,18 @@
 (ns utility-belt.concurrent
   "A set of helpers for working with Java's concurrency constructs"
-  (:import [java.lang Thread$Builder$OfVirtual]
-           [java.util.concurrent
-            Executors
-            ExecutorService
-            TimeUnit
-            ScheduledThreadPoolExecutor
-            ThreadFactory
-            ThreadPoolExecutor$AbortPolicy
-            TimeUnit]
-           [java.util.concurrent.atomic AtomicLong]))
+  (:import
+   ;; see more here why this is used: https://javadoc.io/doc/io.timeandspace/cron-scheduler/latest/io/timeandspace/cronscheduler/CronScheduler.html
+   [io.timeandspace.cronscheduler CronScheduler CronSchedulerBuilder CronTask]
+   [java.lang Thread$Builder$OfVirtual]
+   [java.util.concurrent
+    Executors
+    ExecutorService
+    TimeUnit
+    ScheduledThreadPoolExecutor
+    ThreadFactory
+    ThreadPoolExecutor$AbortPolicy
+    TimeUnit]
+   [java.util.concurrent.atomic AtomicLong]))
 
 (set! *warn-on-reflection* true)
 
@@ -107,52 +110,54 @@
 
 (defn make-scheduler-pool
   "Create a new scheduler pool for running recurring tasks."
-  [{:keys [name thread-count] :or {thread-count 2}}]
-  (ScheduledThreadPoolExecutor. ^long thread-count
-                                ^ThreadFactory (thread-factory {:name name :daemon? true})
-                                ;; TODO: add logging variant of this:
-                                (ThreadPoolExecutor$AbortPolicy.)))
+  [{:keys [name]}]
+  ;; resync wall clock every 3 minutes
+  (let [scheduler ^CronScheduler (CronScheduler/create (java.time.Duration/ofMinutes 3))]
+    (CronScheduler/.prestartThread scheduler)
+    scheduler))
 
 (defn scheduler-pool?
   "Check if a given thing is a scheduler pool."
   [thing]
-  (instance? ScheduledThreadPoolExecutor thing))
+  (instance? CronScheduler thing))
 
 (defn shutdown-scheduler-pool
   "Shutdown a scheduler pool, waiting for tasks to complete."
-  [^ScheduledThreadPoolExecutor pool]
+  [^CronScheduler pool]
   (try
-    (.shutdown pool)
-    (.awaitTermination pool 10 java.util.concurrent.TimeUnit/SECONDS)
+    (.shutdownNow pool)
+    (.awaitTermination pool 10 TimeUnit/SECONDS)
     (catch InterruptedException _
       (.shutdownNow pool)
       (.interrupt (Thread/currentThread)))))
 
-(def ^:private modes #{::fixed-rate ::fixed-delay})
+(defn- fn->cron-task
+  "Turns a Clojure function into a CronTask.
+  While also protecting against clock drift by checking the scheduled run time
+  See here: https://javadoc.io/doc/io.timeandspace/cron-scheduler/latest/io/timeandspace/cronscheduler/CronScheduler.html
+  "
+  [a-fn]
+  (reify CronTask
+    (run [_this _scheduled-run-time-ms]
+      (a-fn))))
 
 (defn schedule-task
   "Schedule a recurring task running (very roughly) every `period-ms` milliseconds.
-  and executing the `handler` function."
-  [^ScheduledThreadPoolExecutor pool {:keys [handler period-ms delay-ms mode]
-                                      :or {delay-ms 0
-                                           mode ::fixed-rate}}]
+  and executing the `handler` function.
+  Underlying scheduler class will also attempt to compensate for clock drift, unlike Java's ScheduledThreadPoolExecutor, so your tasks will run more reliably at the expected intervals."
+  [^CronScheduler pool {:keys [handler period-ms delay-ms mode]
+                        :or {delay-ms 0}}]
   {:pre [(fn? handler)
          (nat-int? period-ms)
-         (not (neg? delay-ms))
-         (modes mode)]}
+         (not (neg? delay-ms))]}
 
-  (cond
-    (= mode ::fixed-rate) (ScheduledThreadPoolExecutor/.scheduleAtFixedRate pool
-                                                                            ^Runnable handler
-                                                                            ^long delay-ms
-                                                                            ^long period-ms
-                                                                            TimeUnit/MILLISECONDS)
-
-    (= mode ::fixed-delay) (ScheduledThreadPoolExecutor/.scheduleWithFixedDelay pool
-                                                                                ^Runnable handler
-                                                                                ^long delay-ms
-                                                                                ^long period-ms
-                                                                                TimeUnit/MILLISECONDS)
-
-    :else (throw (ex-info "Invalid mode for scheduling task"
-                          {:mode mode :valid-modes modes}))))
+  ;; NOTE: this is to catch code which uses different scheduler mmodes - because we're now using a different
+  ;;       scheduler implementation, we only support fixed-rate scheduling,
+  ;;       and fixed-delay scheduling is not supported, so we want to throw if we see that mode being used.
+  (when mode
+    (throw (ex-info "Only fixed-rate scheduling is supported" {:mode mode})))
+  (CronScheduler/.scheduleAtFixedRate pool
+                                      ^long delay-ms
+                                      ^long period-ms
+                                      TimeUnit/MILLISECONDS
+                                      ^CronTask (fn->cron-task handler)))

--- a/src/utility_belt/concurrent.clj
+++ b/src/utility_belt/concurrent.clj
@@ -2,15 +2,13 @@
   "A set of helpers for working with Java's concurrency constructs"
   (:import
    ;; see more here why this is used: https://javadoc.io/doc/io.timeandspace/cron-scheduler/latest/io/timeandspace/cronscheduler/CronScheduler.html
-   [io.timeandspace.cronscheduler CronScheduler CronSchedulerBuilder CronTask]
+   [io.timeandspace.cronscheduler CronScheduler CronSchedulerBuilder CronTask OneShotTasksShutdownPolicy]
    [java.lang Thread$Builder$OfVirtual]
    [java.util.concurrent
     Executors
     ExecutorService
     TimeUnit
-    ScheduledThreadPoolExecutor
     ThreadFactory
-    ThreadPoolExecutor$AbortPolicy
     TimeUnit]
    [java.util.concurrent.atomic AtomicLong]))
 
@@ -125,12 +123,16 @@
   [thing]
   (instance? CronScheduler thing))
 
+(def shutdown-policy (OneShotTasksShutdownPolicy/valueOf "DISCARD_DELAYED"))
+
 (defn shutdown-scheduler-pool
   "Shutdown a scheduler pool, waiting for tasks to complete."
   [^CronScheduler pool]
   (try
-    (.shutdownNow pool)
-    (.awaitTermination pool 10 TimeUnit/SECONDS)
+    (.shutdown pool ^OneShotTasksShutdownPolicy shutdown-policy)
+    (when-not (.awaitTermination pool 10 TimeUnit/SECONDS)
+      (.shutdownNow pool))
+    ;; handle the case where the thread is interrupted  - we can't block for too long
     (catch InterruptedException _
       (.shutdownNow pool)
       (.interrupt (Thread/currentThread)))))

--- a/src/utility_belt/concurrent.clj
+++ b/src/utility_belt/concurrent.clj
@@ -111,8 +111,12 @@
 (defn make-scheduler-pool
   "Create a new scheduler pool for running recurring tasks."
   [{:keys [name]}]
-  ;; resync wall clock every 3 minutes
-  (let [scheduler ^CronScheduler (CronScheduler/create (java.time.Duration/ofMinutes 3))]
+  ;; resync wall clock every 5 minutes - which is recommended for server side use as per javadoc
+  (let [scheduler-builder ^CronSchedulerBuilder (CronScheduler/newBuilder (java.time.Duration/ofMinutes 5))
+        scheduler (-> scheduler-builder
+                      (.setThreadFactory (thread-factory {:name (str name "-scheduler")
+                                                          :daemon? true}))
+                      (.build))]
     (CronScheduler/.prestartThread scheduler)
     scheduler))
 

--- a/test/utility_belt/component/scheduler_test.clj
+++ b/test/utility_belt/component/scheduler_test.clj
@@ -45,3 +45,22 @@
             :task-2
             :task-2]
            (->> @system :store deref (take 8) sort)))))
+
+(deftest task-error-resilience-test
+  (testing "a task that throws keeps firing on subsequent ticks"
+    (let [counter (atom 0)
+          error-sys (c/map->system
+                     {:scheduler (comp.scheduler/create-pool {:name "ErrorTest"})
+                      :task (component/using
+                             (comp.scheduler/create-task {:name "error-task"
+                                                          :period-ms 100
+                                                          :handler (fn [_]
+                                                                     (swap! counter inc)
+                                                                     (throw (ex-info "boom" {})))})
+                             [:scheduler])})
+          started (component/start error-sys)]
+      (try
+        (Thread/sleep 400)
+        (is (> @counter 1) "task should have fired multiple times despite throwing")
+        (finally
+          (component/stop started))))))

--- a/test/utility_belt/concurrent_test.clj
+++ b/test/utility_belt/concurrent_test.clj
@@ -76,6 +76,18 @@
       (is (= [1 2 3 4 5 6]
              (sort results))))))
 
+(deftest schedule-task-rejects-mode-test
+  (testing "passing :mode throws because only fixed-rate is supported"
+    (let [pool (concurrent/make-scheduler-pool {:name "mode-test" :thread-count 1})]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Only fixed-rate scheduling is supported"
+                              (concurrent/schedule-task pool {:handler (fn [])
+                                                              :period-ms 100
+                                                              :mode :fixed-delay})))
+        (finally
+          (concurrent/shutdown-scheduler-pool pool))))))
+
 (deftest scheduler-task-modes-test
   (testing "fixed rate"
     (let [pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})]

--- a/test/utility_belt/concurrent_test.clj
+++ b/test/utility_belt/concurrent_test.clj
@@ -78,7 +78,7 @@
 
 (deftest scheduler-task-modes-test
   (testing "fixed rate"
-    (with-open [^java.util.concurrent.ScheduledThreadPoolExecutor pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})]
+    (let [pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})]
       (let [start-time (System/currentTimeMillis)
             state (atom [])
             task (fn []
@@ -103,33 +103,6 @@
           (Thread/sleep 350)
 
           (testing "after another 300ms, the task ran again, and the state is updated without waiting on previous tasks"
-            (is (= [200 400 600] (mapv round-down @state))))))))
+            (is (= [200 400 600] (mapv round-down @state))))))
 
-  (testing "fixed delay"
-    (with-open [^java.util.concurrent.ScheduledThreadPoolExecutor pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})]
-      (let [start-time (System/currentTimeMillis)
-            state (atom [])
-            task (fn []
-                   (Thread/sleep 200)
-                   (swap! state conj (- (System/currentTimeMillis) ^long start-time)))
-
-            round-down (fn [ms]
-                         (let [round-to 100]
-                           (* (quot ms round-to) round-to)))]
-
-        (testing "scheduling a task with fixed-delay will cause the the task fire only after previous finished"
-          (concurrent/schedule-task pool {:handler task
-                                          :mode ::concurrent/fixed-delay
-                                          :period-ms 100})
-
-          (is (empty? @state))
-
-          (Thread/sleep 300)
-
-          (testing "even though we scheduled it to run every 100ms, it only ran once because task blocks for 200ms"
-            (is (= [200] (mapv round-down @state))))
-
-          (Thread/sleep 300)
-
-          (testing "after another 300ms, the task ran again, and the state is updated"
-            (is (= [200 500] (mapv round-down @state)))))))))
+      (concurrent/shutdown-scheduler-pool pool))))

--- a/test/utility_belt/concurrent_test.clj
+++ b/test/utility_belt/concurrent_test.clj
@@ -84,37 +84,55 @@
                               #"Only fixed-rate scheduling is supported"
                               (concurrent/schedule-task pool {:handler (fn [])
                                                               :period-ms 100
-                                                              :mode :fixed-delay})))
+                                                              :mode ::concurrent/fixed-delay})))
         (finally
           (concurrent/shutdown-scheduler-pool pool))))))
 
-(deftest scheduler-task-modes-test
-  (testing "fixed rate"
-    (let [pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})]
-      (let [start-time (System/currentTimeMillis)
-            state (atom [])
-            task (fn []
-                   (Thread/sleep 200)
-                   (swap! state conj (- (System/currentTimeMillis) ^long start-time)))
+(defn round-down [ms]
+  (let [round-to 100]
+    (* (quot ms round-to) round-to)))
 
-            round-down (fn [ms]
-                         (let [round-to 100]
-                           (* (quot ms round-to) round-to)))]
+(deftest scheduler-test
+  (let [pool (concurrent/make-scheduler-pool {:name "test" :thread-count 1})
+        start-time (System/currentTimeMillis)
+        state (atom [])
+        task (fn []
+               (Thread/sleep 200)
+               (swap! state conj (- (System/currentTimeMillis) ^long start-time)))]
 
-        (testing "scheduling a task with fixed-rate will cause the the task fire regardless of previous execution"
-          (concurrent/schedule-task pool {:handler task
-                                          ;; :mode ::concurrent/fixed-rate - DEFAULT
-                                          :period-ms 100})
+    (testing "scheduling a task with fixed-rate will cause the the task fire regardless of previous execution"
+      (concurrent/schedule-task pool {:handler task
+                                      :period-ms 100})
 
-          (is (empty? @state))
+      (is (empty? @state))
 
-          (Thread/sleep 300)
+      (Thread/sleep 300)
 
-          (is (= [200] (mapv round-down @state)))
+      (is (= [200] (mapv round-down @state)))
 
-          (Thread/sleep 350)
+      (Thread/sleep 350)
 
-          (testing "after another 300ms, the task ran again, and the state is updated without waiting on previous tasks"
-            (is (= [200 400 600] (mapv round-down @state))))))
+      (testing "after another 300ms, the task ran again, and the state is updated without waiting on previous tasks"
+        (is (= [200 400 600] (mapv round-down @state))))
 
       (concurrent/shutdown-scheduler-pool pool))))
+
+(deftest shutdown-long-task-test
+  (testing " if scheduled task takes longer than shutdown wait time, the pool will be forcefully shutdown and the task will be interrupted"
+
+    (let [pool (concurrent/make-scheduler-pool {:name "shutdown-test" :thread-count 1})
+          has-run? (atom false)
+          has-finished? (atom false)
+          task (fn []
+                 (try
+                   (reset! has-run? true)
+                   (Thread/sleep 12000) ;; over the 10s deadline
+                   (reset! has-finished? true)
+                   (catch InterruptedException _)))]
+
+      (concurrent/schedule-task pool {:handler task :period-ms 1000})
+      (is (concurrent/shutdown-scheduler-pool pool))
+
+      (is (= true @has-run?))
+      (is (= false @has-finished?)
+          "Task should not have finished because it should have been interrupted due to shutdown timeout"))))


### PR DESCRIPTION
Switches underlying scheduler machinery to `CronScheduler`, despite its name - cron schedules are not supported yet, that come later as I need to extract more code from my old project.

As a consequence, support for different execution modes (fixed rate vs fixed delay) is dropped - only 'fixed rate' is supported. Since a task scheduler which is supposed to keep execution in sync with the clock cannot run in fixed delay mode, and I still haven't had the need for it anyway. 


References:
- https://github.com/TimeAndSpaceIO/CronScheduler?tab=readme-ov-file#cronscheduler-a-reliable-java-scheduler-for-external-interactions
- https://leventov.medium.com/cronscheduler-a-reliable-java-scheduler-for-external-interactions-cb7ce4a4f2cd