### PR TITLE
allow plain function for component map fn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 .hgignore
 .hg/
 /.java-version
+.clj-kondo/
+.lsp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v3.1.1-SNAPSHOT
+
+* feat: `:component-map-fn` now accepts a plain function in addition to a qualified symbol for `setup-for-dev`.
+
 ### v3.1.0
 
 * feat: add virtual thread support to Jetty component

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 > Although seemingly unremarkable in appearance, the utility belt is one of Batman's most important tools in fighting crime.
 
-
 ## About
 
 [Utility belt](https://github.com/nomnom-insights/nomnom.utility-belt) started at [EnjoyHQ](https://enjoyhq.com) as a way of sharing code that didn't belong anywhere else but was useful to have and use across services and libraries.
@@ -11,22 +10,16 @@ This fork carries on that tradition, but further reduces the scope so that it pr
 
 Thank you to [Peerspace](https://peerspace.com) for their continued support in maintaining this library.
 
-
 ## Installation
 
 `utility-belt` is released to Clojars.
 
-
 - [![Clojars Project](https://img.shields.io/clojars/v/org.clojars.lukaszkorecki/utility-belt.svg)](https://clojars.org/org.clojars.lukaszkorecki/utility-belt)
 - [![Clojars Project](https://img.shields.io/clojars/v/org.clojars.lukaszkorecki/utility-belt.svg?include_prereleases)](https://clojars.org/org.clojars.lukaszkorecki/utility-belt)
 
-
 ## Documentation
 
-
-
 ### General utilities
-
 
 - `utility-belt.base64` - Encoding and decoding to and from base64
 - `utility-belt.compile` - Utilities for conditional code evaluation/loading
@@ -36,7 +29,6 @@ Thank you to [Peerspace](https://peerspace.com) for their continued support in m
 - `utility-belt.lifecycle` - Tools for managing application lifecycle
 
 ### Application utilities
-
 
 #### `utility-belt.lifecycle`
 
@@ -103,31 +95,26 @@ this is a very simple example, your start and stop functions have to obey the sa
 
 ##### production
 
-
 `utility-belt.component.system/setup-for-production` reduces boilerplate for creating a system of components for production environments. It registers a shutdown hook to stop the system when the JVM is shutting down.
 
-Note: `:component-map-fn` **must** return a map of Components, not an instance of `SysteMap`!
+Note: `:component-map-fn` **must** be a plain function or a fully qualified symbol. The fn HAS TO return a map of components, **NOT** a `SystemMap`.
 
 ```clojure
 (ns app.core
   (:require [utility-belt.component.system :as system]
             [app.system]))
 
-
 ;; so that you can access it later via nREPL, optional
 (def sys (atom nil))
-
 
 (def -main [& args]
   (system/setup-for-production {:store sys
                                 ;; NOTE: it has to return a map, not a SystemMap!
-                                ;; it can also be a fully qualified symbol
+                                ;; it can be a plain function or a fully qualified symbol
                                 :component-map-fn app.system/production}))
-
 
 ;; now when the app starts, started system will be in `app.core/sys` atom
 ;; stopping the JVM process will automatically stop the system
-
 ```
 
 ##### dev/test
@@ -136,8 +123,7 @@ Note: `:component-map-fn` **must** return a map of Components, not an instance o
 Additionally it allows for easy system reloading in the REPL, with additional state clean up so that all code used by components is guaranteed to be reloaded.
 - `utility-belt.component.system/setup-for-test` - similar to the above, also includes a `use-test-system` hook for `clojure.test/use-fixtures`
 
-
-Just like in `setup-for-production`, `:component-map-fn` has to be a qualified symbol, and has to return a map of components.
+Just like in `setup-for-production`, `:component-map-fn` must be a plain function or a fully qualified symbol. The fn HAS TO return a map of components, not a SystemMap.
 
 Dev workflow setup:
 
@@ -146,9 +132,8 @@ Dev workflow setup:
   (:require [utility-belt.component.system :as system]
             [app.system]))
 
-
-(let [sys-utils (system/setup-for-dev {;; NOTE: has to be a fully qualified symbol, the fn HAS TO return a map
-                                       ;;       of components, not a SystemMap
+(let [sys-utils (system/setup-for-dev {;; NOTE: can be a plain function or a fully qualified symbol
+                                       ;;       the fn HAS TO return a map of components, not a SystemMap
                                        :component-map-fn 'app.system/development
                                        :reloadable? true})
       {:keys [start-system stop-system get-system] } sys-utils]
@@ -169,7 +154,6 @@ Dev workflow setup:
 ;; code is reloaded and system is started again
 ```
 
-
 For testing env (unit tests, end-to-end system tests etc), the setup is similar:
 
 ```clojure
@@ -177,21 +161,17 @@ For testing env (unit tests, end-to-end system tests etc), the setup is similar:
   (:require [app.system]
             [utility-belt.component.system :as sys]))
 
-
-(let [sys-utils (system/setup-for-test {;; NOTE: has to be a fully-qualified symbol. fn has to return
-                                        ;;       a map, not a SystemMap!
-                                        :component-map-fn 'app.system/test})
+(let [sys-utils (sys/setup-for-test {;; NOTE: can be a plain function or a fully qualified symbol
+                                     ;; fn has to return a map, not a SystemMap!
+                                     :component-map-fn 'app.system/test})
       {:keys [use-test-system get-system]} sys-utils]
   (def system get-system)
   (def with-test-system use-test-system))
-
-
 
 ;; now in tests:
 (ns app.something-test
   (:require [app.test-utils :as test-utils]
             [clojure.test :refer [use-fixtures deftest])))
-
 
 (use-fixtures :each test-utils/with-test-system)
 
@@ -200,7 +180,6 @@ For testing env (unit tests, end-to-end system tests etc), the setup is similar:
                                  :body {:fruit :bananas}}))))
 
 ;; you can also attach extra component map:
-
 
 (use-fixtures :each (fn [test]
                       (test-utils/with-test-system

--- a/src/utility_belt/component/system.clj
+++ b/src/utility_belt/component/system.clj
@@ -50,14 +50,14 @@
   [{:keys [store service component-map-fn use-exit-code-zero-for-graceful-shutdown?]
     :or {use-exit-code-zero-for-graceful-shutdown? true}}]
   {:pre [(type/atom? store)
-         (or (fn? component-map-fn)
+         (or (ifn? component-map-fn)
              (qualified-symbol? component-map-fn))]}
   (let [svc-name (str (or service
                           (first (str/split (str *ns*) #"\."))))
         ;; support both the fn or a fully qual symbol
-        component-map-fn (if (fn? component-map-fn)
-                           component-map-fn
-                           (requiring-resolve component-map-fn))]
+        component-map-fn (if (qualified-symbol? component-map-fn)
+                           (requiring-resolve component-map-fn)
+                           component-map-fn)]
     (reset! store (component/start-system (util.component/map->system (component-map-fn))))
     (lifecycle/add-shutdown-hook :shutdown-system (fn stop! []
                                                     (log/infof "stopping %s" svc-name)
@@ -109,13 +109,13 @@
   - `debug?`: boolean, if true will print start/stop/no-op messages
   "
   [{:keys [component-map-fn reloadable? debug?]}]
-  {:pre [(or (fn? component-map-fn) (qualified-symbol? component-map-fn))]}
+  {:pre [(or (ifn? component-map-fn) (qualified-symbol? component-map-fn))]}
   (when reloadable?
     (assert tools-ns-available? "clojure.tools.namespace.repl is not available, cannot enable code reloading!")
     (disable-reload! *ns*))
-  (let [component-map-fn' (if (fn? component-map-fn)
-                            component-map-fn
-                            (requiring-resolve component-map-fn))
+  (let [component-map-fn' (if (qualified-symbol? component-map-fn)
+                            (requiring-resolve component-map-fn)
+                            component-map-fn)
         sys-ns (-> component-map-fn' meta :ns)
         sys-atom (atom nil)]
     (when reloadable?

--- a/src/utility_belt/component/system.clj
+++ b/src/utility_belt/component/system.clj
@@ -57,7 +57,7 @@
         ;; support both the fn or a fully qual symbol
         component-map-fn (if (fn? component-map-fn)
                            component-map-fn
-                           (fn-sym->ns-sym component-map-fn))]
+                           (requiring-resolve component-map-fn))]
     (reset! store (component/start-system (util.component/map->system (component-map-fn))))
     (lifecycle/add-shutdown-hook :shutdown-system (fn stop! []
                                                     (log/infof "stopping %s" svc-name)
@@ -102,26 +102,25 @@
   There are some caveats but it should work for the most part, as opposed to `component.repl` approach.
 
   Args:
-  - `component-map-fn`: a symbol pointing to a function that returns a **map of components** NOT an instance of `component/SystemMap`
+  - `component-map-fn`: a function or a symbol pointing to it that returns a **map of components**
+                        but NOT an instance of `component/SystemMap`
   - `reloadable?`: boolean, if true, will enable reloading of the system map function and the system itself, default is false
                   When true, it requires `clojure.tools.namespace` to be present in the classpath, otherwise it will throw an error.
   - `debug?`: boolean, if true will print start/stop/no-op messages
   "
-  [{:keys [component-map-fn
-           reloadable?
-           debug?]}]
-  {:pre [(qualified-symbol? component-map-fn)]}
+  [{:keys [component-map-fn reloadable? debug?]}]
+  {:pre [(or (fn? component-map-fn) (qualified-symbol? component-map-fn))]}
   (when reloadable?
     (assert tools-ns-available? "clojure.tools.namespace.repl is not available, cannot enable code reloading!")
     (disable-reload! *ns*))
-
-  (let [sys-ns (find-ns (symbol (namespace component-map-fn)))
+  (let [component-map-fn' (if (fn? component-map-fn)
+                            component-map-fn
+                            (requiring-resolve component-map-fn))
+        sys-ns (-> component-map-fn' meta :ns)
         sys-atom (atom nil)]
-
     (when reloadable?
       ;; always reload system namespace - so we have to tell ctn.repl about this
       (alter-meta! sys-ns merge #:clojure.tools.namespace.repl{:load true :unload true}))
-
     {:start-system (fn start-system'
                      ([]
                       (start-system' {}))
@@ -137,12 +136,11 @@
                                               (log/debugf "Starting system in %s" sys-ns))
                                             (when reloadable?
                                               (refresh))
-                                            (-> ((requiring-resolve component-map-fn))
+                                            (-> (component-map-fn')
                                                 (merge additional-component-map)
                                                 component/map->SystemMap
                                                 component/start)))))
                       ::started))
-
      :stop-system (fn stop-system' []
                     (swap! sys-atom
                            (fn [sys]
@@ -155,7 +153,6 @@
                                (when debug?
                                  (log/debugf "System not running in %s" sys-ns)))))
                     ::stopped)
-
      :get-system (fn get-system' []
                    @sys-atom)}))
 

--- a/test/utility_belt/component/system_test.clj
+++ b/test/utility_belt/component/system_test.clj
@@ -1,27 +1,30 @@
 (ns utility-belt.component.system-test
   (:require [clojure.test :refer [deftest testing is]]
-            [utility-belt.component :as util.component]
-            [utility-belt.component.system :as util.system]
+            [utility-belt.component :refer [map->component]]
+            [utility-belt.component.system :refer [setup-for-production
+                                                   setup-for-dev
+                                                   setup-for-test]]
             [utility-belt.lifecycle :as lifecycle]))
+
+(def fn-symbol
+  'utility-belt.component.system-test/make-system)
 
 (def counter
   (atom 0))
 
 (defn make-system []
   {:static :value
-   :thing (-> {:start (fn [this]
-                        (swap! counter inc)
-                        (assoc this :started true :stopped false))
-               :stop (fn [this]
-                       (swap! counter dec)
-                       (assoc this :stopped true :started false))}
-              util.component/map->component)})
+   :thing (map->component {:start (fn [this]
+                                    (swap! counter inc)
+                                    (assoc this :started true :stopped false))
+                           :stop (fn [this]
+                                   (swap! counter dec)
+                                   (assoc this :stopped true :started false))})})
 
 (defn- assert-prod-behavior [component-map-fn]
   (let [store (atom nil)]
-    (-> {:store store
-         :component-map-fn component-map-fn}
-        util.system/setup-for-production)
+    (setup-for-production {:store store
+                           :component-map-fn component-map-fn})
     (is (some? @store))
     (is (= :value (-> @store :static)))
     (is (= 1 @counter))
@@ -30,14 +33,13 @@
 
 (deftest setup-for-production-test
   (testing "passing qualified symbol for component map fn"
-    (assert-prod-behavior 'utility-belt.component.system-test/make-system))
+    (assert-prod-behavior fn-symbol))
   (testing "passing plain function for component map fn"
-    (assert-prod-behavior utility-belt.component.system-test/make-system)))
+    (assert-prod-behavior fn-symbol)))
 
 (defn- assert-dev-behavior [component-map-fn]
-  (let [control (-> {:component-map-fn component-map-fn
-                     :reloadable? false}
-                    util.system/setup-for-dev)
+  (let [control (setup-for-dev {:component-map-fn component-map-fn
+                                :reloadable? false})
         {:keys [start-system stop-system get-system]} control]
     (testing "system can be started via provided fns"
       (testing "system starts only once"
@@ -60,19 +62,17 @@
 
 (deftest setup-for-dev-test
   (testing "passing qualified symbol for component map fn"
-    (assert-dev-behavior 'utility-belt.component.system-test/make-system))
+    (assert-dev-behavior fn-symbol))
   (testing "passing plain function for component map fn"
-    (assert-dev-behavior utility-belt.component.system-test/make-system)))
+    (assert-dev-behavior fn-symbol)))
 
 (deftest setup-for-test-test
   (testing "provides utility for unit tests"
-    (let [{:keys [use-test-system get-system]} (util.system/setup-for-test {:component-map-fn 'utility-belt.component.system-test/make-system})]
-
+    (let [{:keys [use-test-system get-system]} (setup-for-test {:component-map-fn fn-symbol})]
       (testing "within the hook, system is started and can be used"
         (use-test-system (fn []
                            (is (= :value (-> (get-system) :static)))
                            (is (= true (-> (get-system) :thing :started)))
                            (is (= 1 @counter)))))
-
       (testing "nothing is running, again"
         (is (zero? @counter))))))

--- a/test/utility_belt/component/system_test.clj
+++ b/test/utility_belt/component/system_test.clj
@@ -1,46 +1,68 @@
 (ns utility-belt.component.system-test
   (:require [clojure.test :refer [deftest testing is]]
             [utility-belt.component :as util.component]
-            [utility-belt.component.system :as util.system]))
+            [utility-belt.component.system :as util.system]
+            [utility-belt.lifecycle :as lifecycle]))
 
 (def counter
   (atom 0))
 
 (defn make-system []
   {:static :value
-   :thing (util.component/map->component {:start (fn [this]
-                                                   (swap! counter inc)
-                                                   (assoc this :started true :stopped false))
+   :thing (-> {:start (fn [this]
+                        (swap! counter inc)
+                        (assoc this :started true :stopped false))
+               :stop (fn [this]
+                       (swap! counter dec)
+                       (assoc this :stopped true :started false))}
+              util.component/map->component)})
 
-                                          :stop (fn [this]
-                                                  (swap! counter dec)
-                                                  (assoc this :stopped true :started false))})})
+(defn- assert-prod-behavior [component-map-fn]
+  (let [store (atom nil)]
+    (-> {:store store
+         :component-map-fn component-map-fn}
+        util.system/setup-for-production)
+    (is (some? @store))
+    (is (= :value (-> @store :static)))
+    (is (= 1 @counter))
+    (is (contains? @lifecycle/registerd-hooks :shutdown-system))
+    (lifecycle/remove-shutdown-hooks!)))
 
-(deftest setup-for-dev-test
-  (let [{:keys [start-system stop-system get-system]} (util.system/setup-for-dev {:component-map-fn 'utility-belt.component.system-test/make-system
-                                                                                  :reloadable? false})]
+(deftest setup-for-production-test
+  (testing "passing qualified symbol for component map fn"
+    (assert-prod-behavior 'utility-belt.component.system-test/make-system))
+  (testing "passing plain function for component map fn"
+    (assert-prod-behavior utility-belt.component.system-test/make-system)))
 
+(defn- assert-dev-behavior [component-map-fn]
+  (let [control (-> {:component-map-fn component-map-fn
+                     :reloadable? false}
+                    util.system/setup-for-dev)
+        {:keys [start-system stop-system get-system]} control]
     (testing "system can be started via provided fns"
       (testing "system starts only once"
         (start-system)
         (start-system)
         (is (= 1 @counter)))
-
       (testing "we can get the 'components'"
         (is (= :value (-> (get-system) :static)))))
-
     (testing "stopping"
       (stop-system)
-
       (is (nil? (-> (get-system) :static)))
-
       (testing "stop handler was called on the component"
         (is (zero? @counter))))
-
     (testing "starting again, but with extra components"
       (start-system {:another-static :another-thing})
+      (is (= 1 @counter))
       (is (= :another-thing (-> (get-system) :another-static)))
-      (stop-system))))
+      (stop-system)
+      (is (zero? @counter)))))
+
+(deftest setup-for-dev-test
+  (testing "passing qualified symbol for component map fn"
+    (assert-dev-behavior 'utility-belt.component.system-test/make-system))
+  (testing "passing plain function for component map fn"
+    (assert-dev-behavior utility-belt.component.system-test/make-system)))
 
 (deftest setup-for-test-test
   (testing "provides utility for unit tests"

--- a/test/utility_belt/component/system_test.clj
+++ b/test/utility_belt/component/system_test.clj
@@ -22,6 +22,7 @@
                                    (assoc this :stopped true :started false))})})
 
 (defn- assert-prod-behavior [component-map-fn]
+  (reset! counter 0)
   (let [store (atom nil)]
     (setup-for-production {:store store
                            :component-map-fn component-map-fn})
@@ -38,6 +39,7 @@
     (assert-prod-behavior fn-symbol)))
 
 (defn- assert-dev-behavior [component-map-fn]
+  (reset! counter 0)
   (let [control (setup-for-dev {:component-map-fn component-map-fn
                                 :reloadable? false})
         {:keys [start-system stop-system get-system]} control]
@@ -68,6 +70,7 @@
 
 (deftest setup-for-test-test
   (testing "provides utility for unit tests"
+    (reset! counter 0)
     (let [{:keys [use-test-system get-system]} (setup-for-test {:component-map-fn fn-symbol})]
       (testing "within the hook, system is started and can be used"
         (use-test-system (fn []


### PR DESCRIPTION
Update [utility-belt](https://github.com/lukaszkorecki/utility-belt)'s setup-for-dev to accept a function as well as a qualified symbol for component-map-fn, like setup-for-production does.