### PR TITLE
Updates to Base64 support, adds utils for hashing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.lukaszkorecki/utility-belt "3.1.2-SNAPSHOT"
+(defproject org.clojars.lukaszkorecki/utility-belt "3.2.0-SNAPSHOT"
   :description "Some of the tools you'll ever need to fight crime and write Clojure stuffs"
   :license "MIT"
   :url "https://github.com/lukaszkorecki/utility-belt"

--- a/src/utility_belt/base64.clj
+++ b/src/utility_belt/base64.clj
@@ -52,10 +52,10 @@
 (defn decode->str
   "Decode from bytes or string to string"
   (^String [base64]
-   (decode->str base64 default-charset))
-  (^String [base64 ^String encoding]
+   (decode->str base64 {:encoding default-charset}))
+  (^String [base64 {:keys [url-safe? encoding]}]
    {:pre [(Charset/isSupported encoding)]}
-   (bytes->str (decode base64) encoding)))
+   (bytes->str (decode base64 {:url-safe? url-safe?}) encoding)))
 
 ;; ENCODING
 

--- a/src/utility_belt/base64.clj
+++ b/src/utility_belt/base64.clj
@@ -53,7 +53,8 @@
   "Decode from bytes or string to string"
   (^String [base64]
    (decode->str base64 {:encoding default-charset}))
-  (^String [base64 {:keys [url-safe? encoding]}]
+  (^String [base64 {:keys [url-safe? encoding]
+                    :or {encoding default-charset}}]
    {:pre [(Charset/isSupported encoding)]}
    (bytes->str (decode base64 {:url-safe? url-safe?}) encoding)))
 

--- a/src/utility_belt/base64.clj
+++ b/src/utility_belt/base64.clj
@@ -4,20 +4,50 @@
    [java.nio.charset Charset StandardCharsets]
    [java.util Base64 Base64$Decoder Base64$Encoder]))
 
-(def ^Base64$Decoder decoder (Base64/getDecoder))
-(def ^Base64$Encoder encoder (Base64/getEncoder))
-
+(set! *warn-on-reflection* true)
 (def default-charset (.toString StandardCharsets/UTF_8))
+
+(defn ->bytes
+  "Ensure data is bytes"
+  ^bytes
+  ([data]
+   (->bytes data default-charset))
+  ([data ^String encoding]
+   {:pre [(or (bytes? data) (string? data))
+          (Charset/isSupported encoding)]}
+   (cond
+     (bytes? data) data
+     (string? data) (.getBytes ^String data encoding))))
+
+(defn bytes->str
+  ^String
+  ([^bytes d]
+   (bytes->str d default-charset))
+  ([^bytes d ^String charset]
+   (String. d charset)))
+
+;; DECODING
+
+(def ^Base64$Decoder decoder (Base64/getDecoder))
+(def ^Base64$Decoder decoder-url-safe (Base64/getUrlDecoder))
+
+(defn ^:private opts->decoder* ^Base64$Encoder [url-safe?]
+  (if url-safe?
+    decoder-url-safe
+    decoder))
+
+(def ^:private opts->decoder (memoize opts->decoder*))
 
 (defn decode
   "Decode from bytes or string to bytes"
-  ^bytes [base64]
+  ^bytes [base64 & {:keys [url-safe?]
+                    :or {url-safe? false}}]
   {:pre [(or (bytes? base64) (string? base64))]}
   (byte-array
-    ;; needs to cond on type to stop reflection
+   ;; needs to cond on type to stop reflection
    (cond
-     (bytes? base64) (.decode decoder ^bytes base64)
-     (string? base64) (.decode decoder ^String base64))))
+     (bytes? base64) (Base64$Decoder/.decode (opts->decoder url-safe?) ^bytes base64)
+     (string? base64) (Base64$Decoder/.decode (opts->decoder url-safe?) ^String base64))))
 
 (defn decode->str
   "Decode from bytes or string to string"
@@ -25,29 +55,45 @@
    (decode->str base64 default-charset))
   (^String [base64 ^String encoding]
    {:pre [(Charset/isSupported encoding)]}
-   (String. (decode base64) encoding)))
+   (bytes->str (decode base64) encoding)))
 
-(defn- to-bytes
-  "Ensure data is bytes"
-  ^bytes [data ^String encoding]
-  {:pre [(or (bytes? data) (string? data))
-         (Charset/isSupported encoding)]}
+;; ENCODING
+
+(def ^Base64$Encoder encoder (Base64/getEncoder))
+(def ^Base64$Encoder encoder-without-padding (Base64$Encoder/.withoutPadding (Base64/getEncoder)))
+(def ^Base64$Encoder encoder-url-safe (Base64/getUrlEncoder))
+(def ^Base64$Encoder encoder-without-padding-url-safe (Base64$Encoder/.withoutPadding (Base64/getUrlEncoder)))
+
+(defn ^:private opts->encoder* ^Base64$Encoder [padding? url-safe?]
   (cond
-    (bytes? data) data
-    (string? data) (.getBytes ^String data encoding)))
+    (and padding? url-safe?) encoder-url-safe
+    (and padding? (not url-safe?)) encoder
+    (and (not padding?) url-safe?) encoder-without-padding-url-safe
+    (and (not padding?) (not url-safe?)) encoder-without-padding))
+
+(def ^:private opts->encoder (memoize opts->encoder*))
 
 (defn encode
-  "Encode string or bytes to bytes"
-  (^bytes [data]
-   (encode data default-charset))
-  (^bytes [data ^String encoding]
-   (let [^bytes to-encode (to-bytes data encoding)]
-     (.encode encoder to-encode))))
+  "Encode string or bytes to bytes
+   Accepts an optional map of:
+   - :encoding - charset name to use, defaults to UTF-8
+   - :padding?  - encode with padding (default) or not
+   - :url-safe? - encode url safe or not (default)"
+  ^bytes [data & {:keys [encoding
+                         url-safe?
+                         padding?]
+                  :or {encoding default-charset
+                       url-safe? false
+                       padding? true}}]
+  (let [^bytes to-encode (->bytes data encoding)
+        encoder (opts->encoder padding? url-safe?)]
+    (Base64$Encoder/.encode encoder to-encode)))
 
 (defn encode->str
   "Encode string or bytes to string"
   (^String [data]
-   (encode->str data default-charset))
-  (^String [data ^String encoding]
-   (-> data (encode encoding) (String. encoding))))
-
+   (encode->str data {}))
+  (^String [data {:keys [encoding]
+                  :or {encoding default-charset}
+                  :as opts}]
+   (bytes->str (encode data opts) ^String encoding)))

--- a/src/utility_belt/hashing.clj
+++ b/src/utility_belt/hashing.clj
@@ -1,0 +1,16 @@
+(ns utility-belt.hashing
+  (:require [utility-belt.base64 :refer [->bytes]])
+ (:import
+   [java.security MessageDigest]))
+
+
+
+(defn sha256 ^bytes [thing]
+  (let [digest (MessageDigest/getInstance "SHA-256")]
+    (MessageDigest/.update digest ^bytes (->bytes thing))
+    (MessageDigest/.digest digest)))
+
+(defn md5 ^bytes [thing]
+  (let [digest (MessageDigest/getInstance "MD5")]
+    (MessageDigest/.update digest ^bytes (->bytes thing))
+    (MessageDigest/.digest digest)))

--- a/test/utility_belt/base64_test.clj
+++ b/test/utility_belt/base64_test.clj
@@ -1,13 +1,25 @@
 (ns utility-belt.base64-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [utility-belt.base64 :as base64]))
+   [utility-belt.base64 :as base64]
+   [utility-belt.hashing :as hashing]))
 
 (def default-charset "UTF-8")
 (def ^String test-str "a test string encoded as base64")
 (def ^bytes test-str-bytes (String/.getBytes test-str ^String default-charset))
 (def ^String test-str-64 "YSB0ZXN0IHN0cmluZyBlbmNvZGVkIGFzIGJhc2U2NA==")
 (def ^bytes test-str-64-bytes (String/.getBytes test-str-64 ^String default-charset))
+
+(deftest factory-arrow-fns-test
+  (testing "decoders"
+    (is (#'base64/opts->decoder* true))
+    (is (#'base64/opts->decoder* false)))
+  (testing "encoders"
+    (is (#'base64/opts->encoder* true true))
+    (is (#'base64/opts->encoder* true false))
+    (is (#'base64/opts->encoder* false true))
+    (is (#'base64/opts->encoder* false false))
+    (is (#'base64/opts->encoder* nil nil))))
 
 (defn same-bytes?
   "= doesn't work with bytes but (= seq seq) compares 1-1"
@@ -16,9 +28,10 @@
 
 (deftest same-bytes-test
   (testing "not same"
-    (is (not (same-bytes? (.getBytes "a" "UTF-8") (.getBytes "b" "UTF-8")))))
+    (is (not (same-bytes? (String/.getBytes "abcdef1234" "UTF-8")
+                          (String/.getBytes "badef1234" "UTF-8")))))
   (testing "same"
-    (is (same-bytes? (.getBytes "a" "UTF-8") (.getBytes "a" "UTF-8")))))
+    (is (same-bytes? (String/.getBytes "abcdef1234" "UTF-8") (String/.getBytes "abcdef1234" "UTF-8")))))
 
 (deftest encode-decode-test
   (testing "decodes bytes"
@@ -35,3 +48,23 @@
   (testing "encodes bytes/strings to string"
     (is (= test-str-64 (base64/encode->str test-str)))
     (is (= test-str-64 (base64/encode->str test-str-bytes)))))
+
+
+
+(deftest encoding-with-opts-test
+  (let [some-bytes (hashing/sha256 "have some 🧀")]
+    (testing "defaults"
+      (is (= "bvRAHOoEG8Zk25KX24xeqpaWKJ5zoDLg7zP+UX65aqg="
+             (base64/encode->str some-bytes))))
+
+    (testing "no padding"
+      (is (= "bvRAHOoEG8Zk25KX24xeqpaWKJ5zoDLg7zP+UX65aqg"
+             (base64/encode->str some-bytes {:padding? false}))))
+
+    (testing "url safe"
+      (is (= "bvRAHOoEG8Zk25KX24xeqpaWKJ5zoDLg7zP-UX65aqg="
+             (base64/encode->str some-bytes {:url-safe? true}))))
+
+    (testing "url safe, no padding"
+      (is (= "bvRAHOoEG8Zk25KX24xeqpaWKJ5zoDLg7zP-UX65aqg"
+             (base64/encode->str some-bytes {:padding? false :url-safe? true}))))))

--- a/test/utility_belt/base64_test.clj
+++ b/test/utility_belt/base64_test.clj
@@ -49,8 +49,6 @@
     (is (= test-str-64 (base64/encode->str test-str)))
     (is (= test-str-64 (base64/encode->str test-str-bytes)))))
 
-
-
 (deftest encoding-with-opts-test
   (let [some-bytes (hashing/sha256 "have some 🧀")]
     (testing "defaults"
@@ -68,3 +66,15 @@
     (testing "url safe, no padding"
       (is (= "bvRAHOoEG8Zk25KX24xeqpaWKJ5zoDLg7zP-UX65aqg"
              (base64/encode->str some-bytes {:padding? false :url-safe? true}))))))
+
+(deftest decoding-with-opts-test
+
+  (testing "round trip"
+    (is (= "🍏  🍌 🧟‍♂️"
+           (-> "🍏  🍌 🧟‍♂️"
+               (base64/encode->str {:url-safe? true})
+               (base64/decode->str {:url-safe? true})))))
+
+  (testing "all the opts"
+    (is (same-bytes? (hashing/sha256 "have some 🧀")
+                     (base64/decode "bvRAHOoEG8Zk25KX24xeqpaWKJ5zoDLg7zP-UX65aqg" {:url-safe? true})))))


### PR DESCRIPTION
- added flags for enabling/disabling padding and url-safe versions of Base64 encoding
- added new `hashing` namespace with SHA25 and MD5 hashing functions, no HMAC yet, it's coming

> [!WARNING]
> Technically changes to `ut.base64` namespace are breaking, but I think it's safe to assume
> that nobody every passed different encoding and only default UTF-8 was used.